### PR TITLE
Fixes #1, Add support for generating source maps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ This module will compile Less files during `mimosa watch` and `mimosa build`.
 ```coffeescript
 less:
   lib: undefined
+  sourceMap: true
   extensions: ["less"]
 ```
 
 * `lib`: You may want to use this module but may not be ready to use the latest version of Less. Using the `lib` property you can provide a specific version of Less if the one being used by this module isn't to your liking. To provide a specific version, you must have it `npm install`ed into your project and then provide it to `lib`. For instance: `lib: require('less')`.
+* `sourceMap`: a less compiler option to turn on/off source maps. They are [Dynamic source maps](http://fitzgeraldnick.com/weblog/46/) which require no extra network hops to retrieve the original source or the map files.
 * `extensions`: an array of strings, the extensions of your Less files.

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,7 @@
 exports.defaults = function() {
   return {
     less: {
+      sourceMap: true,
       extensions: [ "less" ],
     }
   };
@@ -12,6 +13,7 @@ exports.placeholder = function() {
   return "\t\n\n"+
          "  # less:                  # config settings for the Less compiler module\n" +
          "    # lib: undefined       # use this property to provide a specific version of Less\n" +
+         "    # sourceMap: true       # a less compiler option to turn on/off source maps\n" +
          "    # extensions: [\"less\"]   # default extensions for Less files\n";
 };
 
@@ -28,6 +30,10 @@ exports.validate = function( config, validators ) {
       if (config.less.extensions.length === 0) {
         errors.push( "less.extensions cannot be an empty array");
       }
+    }
+
+    if ( config.isBuild ) {
+      config.less.sourceMap = false;
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,11 @@ var compile = function ( mimosaConfig, file, done ) {
 
     try {
       logger.debug( "...then converting to CSS" );
-      result = tree.toCSS();
+      var options = {
+        sourceMap: mimosaConfig.less.sourceMap
+        , outputSourceFiles: true
+      }
+      result = tree.toCSS(options);
     } catch ( ex ) {
       err = ex.type + " Error: " + ex.message;
       if ( ex.filename ) {


### PR DESCRIPTION
Leverage recent feature of the less compiler to generate dynamic source
maps. Added config option to turn on/off and automatically set to false if during build.
Currently doesn't support writing source map out to a separate file.
